### PR TITLE
Fix typo: convetive -> convective

### DIFF
--- a/main/qdstat.cpp
+++ b/main/qdstat.cpp
@@ -401,7 +401,7 @@ const char* Stats::desc(double value) const
         case 1:
           return " large scale";
         case 2:
-          return " convetive";
+          return " convective";
         default:
           return "";
       }
@@ -415,7 +415,7 @@ const char* Stats::desc(double value) const
         case 1:
           return " large scale";
         case 2:
-          return " convetive";
+          return " convective";
         default:
           return "";
       }


### PR DESCRIPTION
There was a typo in translating the precipitation type value.