### PR TITLE
fix(bufr.conf): map modern synop parameters (pressure, visibility, weather, min/max temp)

### DIFF
--- a/cnf/bufr.conf
+++ b/cnf/bufr.conf
@@ -51,3 +51,20 @@
 990411,LOW CLOUD TYPE,LowCloudType,Cl
 990412,MIDDLE CLOUD TYPE,MiddleCloudType,Cm
 990413,HIGH CLOUD TYPE,HighCloudType,Ch
+
+# --- Modern synop (WMO master table v31/v32 high-res template) additions ---
+# The old template's pressure code 007004 is absent/missing in these files;
+# real pressure is in 010051 (MSL) / 010004 (station). Many common synop
+# parameters (visibility, present/past weather, min/max temp, ...) were not
+# mapped at all.
+010051,PRESSURE REDUCED TO MSL,Pressure,PMSL
+010004,PRESSURE,PressureAtStationLevel,P0
+010061,PRESSURE CHANGE,PressureChange,PPP
+010063,CHARACTERISTIC OF PRESSURE TENDENCY,PressureTendency,a
+020001,HORIZONTAL VISIBILITY,Visibility,VV
+020003,PRESENT WEATHER,PresentWeather,ww
+020004,PAST WEATHER (1),PastWeather1,W1
+020005,PAST WEATHER (2),PastWeather2,W2
+012111,MAXIMUM TEMPERATURE,MaximumTemperature,Tmax
+012112,MINIMUM TEMPERATURE,MinimumTemperature,Tmin
+020062,STATE OF THE GROUND,StateOfGround,E


### PR DESCRIPTION
## Problem

For current WMO synop BUFR, bufrtoqd's **`Pressure` output is entirely empty**, and many standard parameters are missing.

`bufr.conf` maps pressure only to `007004`, but in today's synop templates (WMO master table **v31/v32** high-res, and also the older **v13** feeds) `007004` is absent/missing — the real pressure is in **`010051`** (reduced to MSL) and **`010004`** (station level). Visibility (`020001`), present/past weather (`020003`/`020004`/`020005`), min/max temperature (`012111`/`012112`), pressure change/tendency (`010061`/`010063`) and state of ground (`020062`) were not mapped at all.

Evidence (300 real synop reports): `007004` had data in **0**, while `010051` (147), `010004` (167), `020003` (**300/300**) and `020001` (177) carried real data that was being dropped.

## Fix

Add the 11 modern synop mappings (all target qd parameter names exist in newbase).

## Validation (real data, Rocky Linux 9)

- **New synop feed (v32)**: `Pressure` goes from **0/6956** non-missing to populated MSL pressure (1000–1023 hPa); 12 → 22 params.
- **Old-style synop feed (v13)**: same broken pressure (189/28275, ~850 hPa level coords) → real MSL pressure (6776 values); 14 → 24 params.
- **No duplicate `Pressure`** even though files contain both `007004` and `010051` (verified: exactly one Pressure param).
- **Existing parameters byte-identical** (Temperature, DewPoint, Wind, Cloud unchanged) in every category.
- **`amdar` and `sounding` output unchanged** (`qddifference = 0`) — these codes aren't present there, and soundings still map `007004→Pressure` (its pressure-level coordinate).

## Note

The `test/results` expected `.sqd` for the **land** and **buoy** categories will need regenerating, since their output now includes the added parameters. (amdar/sounding expected outputs are unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)